### PR TITLE
feat(frontend): add room page UI for bingo gameplay

### DIFF
--- a/app/room/[roomCode]/page.tsx
+++ b/app/room/[roomCode]/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { callNumber, claimBingo, getRoom, getRoomWebSocketUrl } from "@/lib/api";
+import type { BingoCell, RoomSnapshot } from "@/lib/types";
+
+type RoomPageProps = {
+  params: Promise<{ roomCode: string }>;
+};
+
+export default function RoomPage({ params }: RoomPageProps) {
+  const [roomCode, setRoomCode] = useState("");
+  const [room, setRoom] = useState<RoomSnapshot | null>(null);
+  const [card, setCard] = useState<BingoCell[][]>([]);
+  const [playerId, setPlayerId] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [actionLoading, setActionLoading] = useState(false);
+
+  useEffect(() => {
+    async function init() {
+      const resolvedParams = await params;
+      const code = resolvedParams.roomCode.toUpperCase();
+      setRoomCode(code);
+
+      const storedPlayerId = localStorage.getItem("player_id") || "";
+      const storedCard = localStorage.getItem("player_card");
+
+      setPlayerId(storedPlayerId);
+
+      if (storedCard) {
+        try {
+          setCard(JSON.parse(storedCard));
+        } catch {}
+      }
+
+      try {
+        const snapshot = await getRoom(code);
+        setRoom(snapshot);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load room");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    init();
+  }, [params]);
+
+  useEffect(() => {
+    if (!roomCode) return;
+
+    const ws = new WebSocket(getRoomWebSocketUrl(roomCode));
+
+    ws.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+
+        if (data.room) {
+          setRoom(data.room);
+        }
+      } catch (err) {
+        console.error("WebSocket parse error:", err);
+      }
+    };
+
+    ws.onerror = (err) => {
+      console.error("WebSocket error:", err);
+    };
+
+    return () => {
+      ws.close();
+    };
+  }, [roomCode]);
+
+  const isHost = useMemo(() => {
+    if (!room || !playerId) return false;
+    return room.host_id === playerId;
+  }, [room, playerId]);
+
+  async function handleCallNumber() {
+    if (!roomCode || !playerId) return;
+
+    setActionLoading(true);
+    setError("");
+
+    try {
+      const data = await callNumber(roomCode, playerId);
+      setRoom(data.room);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to call number");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  async function handleClaimBingo() {
+    if (!roomCode || !playerId) return;
+
+    setActionLoading(true);
+    setError("");
+
+    try {
+      const data = await claimBingo(roomCode, playerId);
+      setRoom(data.room);
+
+      if (data.is_valid) {
+        alert("Bingo claim is valid!");
+      } else {
+        alert("Invalid bingo claim.");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to claim bingo");
+    } finally {
+      setActionLoading(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <main className="min-h-screen bg-neutral-950 p-6 text-white">
+        Loading room...
+      </main>
+    );
+  }
+
+  if (error && !room) {
+    return (
+      <main className="min-h-screen bg-neutral-950 p-6 text-white">
+        <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-red-200">
+          {error}
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-neutral-950 px-6 py-8 text-white">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-4xl font-bold">Room {room?.room_code}</h1>
+            <p className="mt-1 text-white/70">Status: {room?.status}</p>
+            <p className="text-white/70">
+              Current number: {room?.current_number ?? "None yet"}
+            </p>
+          </div>
+
+          <div className="flex gap-3">
+            {isHost ? (
+              <button
+                onClick={handleCallNumber}
+                disabled={actionLoading || room?.status === "finished"}
+                className="rounded-xl bg-white px-5 py-3 font-semibold text-black disabled:opacity-60"
+              >
+                Call Number
+              </button>
+            ) : null}
+
+            <button
+              onClick={handleClaimBingo}
+              disabled={actionLoading || room?.status === "finished"}
+              className="rounded-xl border border-white/20 px-5 py-3 font-semibold text-white disabled:opacity-60"
+            >
+              Claim Bingo
+            </button>
+          </div>
+        </div>
+
+        {error ? (
+          <div className="mb-6 rounded-xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="grid gap-6 lg:grid-cols-[1.3fr_0.7fr]">
+          <section className="rounded-2xl border border-white/10 bg-white/5 p-6">
+            <h2 className="mb-4 text-2xl font-semibold">Your Bingo Card</h2>
+
+            <div className="grid grid-cols-5 gap-2">
+              {card.flat().map((cell, index) => (
+                <div
+                  key={index}
+                  className="flex aspect-square items-center justify-center rounded-xl border border-white/10 bg-black/30 text-lg font-semibold"
+                >
+                  {cell}
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="space-y-6">
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+              <h2 className="mb-4 text-2xl font-semibold">Players</h2>
+              <div className="space-y-3">
+                {room?.players.map((player) => (
+                  <div
+                    key={player.player_id}
+                    className="rounded-xl border border-white/10 bg-black/20 px-4 py-3"
+                  >
+                    <div className="font-medium">{player.player_name}</div>
+                    <div className="text-sm text-white/60">
+                      {player.is_host ? "Host" : "Player"}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div className="rounded-2xl border border-white/10 bg-white/5 p-6">
+              <h2 className="mb-4 text-2xl font-semibold">Called Numbers</h2>
+              <div className="flex flex-wrap gap-2">
+                {room?.called_numbers.length ? (
+                  room.called_numbers.map((num) => (
+                    <span
+                      key={num}
+                      className="rounded-full border border-white/10 bg-black/30 px-3 py-1 text-sm"
+                    >
+                      {num}
+                    </span>
+                  ))
+                ) : (
+                  <span className="text-white/60">No numbers called yet.</span>
+                )}
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1562,7 +1561,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1622,7 +1620,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2148,7 +2145,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2492,7 +2488,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3060,7 +3055,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3246,7 +3240,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5420,7 +5413,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5430,7 +5422,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6122,7 +6113,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6285,7 +6275,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6561,7 +6550,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Overview
This PR adds the room page UI for LuckyBingo, where players can view the game state and interact during a match.

## Changes
- Created `app/room/[roomCode]/page.tsx`
- Added room state loading on page open
- Displayed bingo card, players list, and called numbers
- Added host action for calling a number
- Added player action for claiming bingo
- Connected room page to backend room APIs
- Added WebSocket support for real-time room updates

## Why
This page is the main gameplay screen of LuckyBingo. It allows players to enter a room and see live updates as the game progresses.

## Result
- Players can enter a room and view current game data
- Hosts can call numbers
- Players can claim bingo
- Room updates appear in real time

## Notes
- Uses localStorage for player ID and bingo card persistence
- WebSocket is used to sync room activity without manual refresh