### PR TITLE
connected to backend

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -4,7 +4,8 @@ import type {
   RoomSnapshot,
 } from "./types";
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8001";
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000";
+const API_BASE_URL = API_URL.replace(/\/+$/, "");
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
@@ -19,7 +20,7 @@ async function handleResponse<T>(res: Response): Promise<T> {
 }
 
 export async function createRoom(hostName: string): Promise<CreateRoomResponse> {
-  const res = await fetch(`${API_URL}/rooms`, {
+  const res = await fetch(`${API_BASE_URL}/rooms`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -34,7 +35,7 @@ export async function joinRoom(
   roomCode: string,
   playerName: string
 ): Promise<JoinRoomResponse> {
-  const res = await fetch(`${API_URL}/players/join`, {
+  const res = await fetch(`${API_BASE_URL}/players/join`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -49,7 +50,7 @@ export async function joinRoom(
 }
 
 export async function getRoom(roomCode: string): Promise<RoomSnapshot> {
-  const res = await fetch(`${API_URL}/rooms/${roomCode}`, {
+  const res = await fetch(`${API_BASE_URL}/rooms/${roomCode}`, {
     cache: "no-store",
   });
 
@@ -57,7 +58,7 @@ export async function getRoom(roomCode: string): Promise<RoomSnapshot> {
 }
 
 export async function callNumber(roomCode: string, hostId: string) {
-  const res = await fetch(`${API_URL}/rooms/${roomCode}/call-number`, {
+  const res = await fetch(`${API_BASE_URL}/rooms/${roomCode}/call-number`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -69,7 +70,7 @@ export async function callNumber(roomCode: string, hostId: string) {
 }
 
 export async function claimBingo(roomCode: string, playerId: string) {
-  const res = await fetch(`${API_URL}/rooms/${roomCode}/claim-bingo`, {
+  const res = await fetch(`${API_BASE_URL}/rooms/${roomCode}/claim-bingo`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -81,6 +82,6 @@ export async function claimBingo(roomCode: string, playerId: string) {
 }
 
 export function getRoomWebSocketUrl(roomCode: string) {
-  const base = API_URL.replace(/^http/, "ws");
+  const base = API_BASE_URL.replace(/^http/, "ws");
   return `${base}/ws/${roomCode}`;
 }


### PR DESCRIPTION
Enabled CORS in the FastAPI backend so browser calls from Next.js are allowed
Added CORSMiddleware and configurable frontend origins in [main.py:1](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Default allowed origins now include localhost/127.0.0.1 on ports 3000 and 3001 in [main.py:13](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Fixed and normalized frontend API base URL usage
Changed default API target to 127.0.0.1:8000 and removed trailing slash issues in [api.ts:7](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Updated all REST calls and WebSocket URL generation to use normalized base URL in [api.ts:21](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Aligned your frontend environment config with Next.js client env rules
Added NEXT_PUBLIC_API_URL in [.env:2](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/41dd792b5e/resources/app/out/vs/code/electron-browser/workbench/workbench.html)