### PR TITLE
Feat: Public/Private Bingo Rooms + Public Lobby Join (Quick Play)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,12 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
-import { createRoom, joinRoom, reEnterRoom } from "@/lib/api";
+import {
+  createRoom,
+  getPublicRooms,
+  joinRoom,
+  reEnterRoom,
+} from "@/lib/api";
 
 export default function HomePage() {
   const router = useRouter();
@@ -74,7 +79,7 @@ export default function HomePage() {
     setIdentityReady(true);
   }
 
-  async function handleCreateRoom() {
+  async function handleCreateRoom(visibility: "public" | "private") {
     setError("");
     setCreateLoading(true);
 
@@ -86,7 +91,7 @@ export default function HomePage() {
         throw new Error("Player identity not initialized");
       }
 
-      const data = await createRoom(name, playerId);
+      const data = await createRoom(name, playerId, visibility);
 
       localStorage.setItem("player_id", data.player_id);
       localStorage.setItem("room_code", data.room_code);
@@ -123,6 +128,25 @@ export default function HomePage() {
       setError(err instanceof Error ? err.message : "Failed to join room");
     } finally {
       setJoinLoading(false);
+    }
+  }
+
+  async function handleQuickPlay() {
+    setError("");
+
+    try {
+      const rooms = await getPublicRooms();
+
+      if (rooms.length === 0) {
+        setError("No active public lobbies available.");
+        return;
+      }
+
+      const randomIndex = Math.floor(Math.random() * rooms.length);
+      const randomRoom = rooms[randomIndex];
+      await handleJoinRoom(randomRoom.room_code);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to quick play");
     }
   }
 
@@ -229,6 +253,25 @@ export default function HomePage() {
                 onSubmit={handleJoinRoom}
                 loading={joinLoading}
               />
+            </div>
+
+            <div className="rounded-2xl border p-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <div className="font-semibold">Quick Play</div>
+                  <div className="text-sm text-muted-foreground">
+                    Instantly join a random active public room.
+                  </div>
+                </div>
+
+                <Button
+                  type="button"
+                  onClick={handleQuickPlay}
+                  disabled={joinLoading}
+                >
+                  {joinLoading ? "Joining..." : "Quick Play"}
+                </Button>
+              </div>
             </div>
           </>
         ) : null}

--- a/app/room/[roomCode]/page.tsx
+++ b/app/room/[roomCode]/page.tsx
@@ -43,6 +43,7 @@ export default function RoomPage() {
   const [card, setCard] = useState<BingoCell[][]>([]);
   const [playerId, setPlayerId] = useState("");
   const [playerName, setPlayerName] = useState("");
+  const [error, setError] = useState("");
   const [actionLoading, setActionLoading] = useState(false);
   const [markedCells, setMarkedCells] = useState<string[]>([]);
 
@@ -63,10 +64,14 @@ export default function RoomPage() {
       } catch {}
     }
 
-    getRoom(roomCode).then((r) => {
-      setRoom(r);
-      prevHostIdRef.current = r.host_id;
-    });
+    getRoom(roomCode)
+      .then((r) => {
+        setRoom(r);
+        prevHostIdRef.current = r.host_id;
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : "Failed to load room");
+      });
   }, [roomCode]);
 
   /* WEBSOCKET */
@@ -121,35 +126,82 @@ export default function RoomPage() {
 
   /* ACTIONS */
   async function handleCallNumber() {
-    const res = await callNumber(roomCode, playerId);
-    setRoom(res.room);
+    setError("");
+    try {
+      const res = await callNumber(roomCode, playerId);
+      setRoom(res.room);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to call number");
+    }
   }
 
   async function handleClaimBingo() {
     if (actionLoading) return;
+    setError("");
     setActionLoading(true);
     try {
       const res = await claimBingo(roomCode, playerId);
       if (!res.is_valid) setShowInvalidBingoModal(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to claim bingo");
     } finally {
       setActionLoading(false);
     }
   }
 
   async function handleEndSession() {
-    await endSession(roomCode, playerId);
+    setError("");
+    try {
+      await endSession(roomCode, playerId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to end session");
+    }
   }
 
   async function handleLeaveConfirmed() {
-    await leaveRoom(roomCode, playerId);
-    localStorage.removeItem("room_code");
+    setError("");
+    try {
+      await leaveRoom(roomCode, playerId);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to leave room";
+      if (message !== "Room not found") {
+        setError(message);
+        return;
+      }
+    }
     router.push("/");
   }
 
-  if (!room) return <p className="p-6">Loading...</p>;
+  if (!room) {
+    return (
+      <main className="p-6 space-y-4">
+        {error ? (
+          <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+            {error}
+          </div>
+        ) : (
+          <p>Loading...</p>
+        )}
+        <div>
+          <button
+            className="rounded-md border px-3 py-2 text-sm"
+            onClick={() => router.push("/")}
+          >
+            Back To Home
+          </button>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <main className="p-6 space-y-6">
+      {error ? (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
       {/* Host promotion toast */}
       {showHostPromotionToast && (
         <div className="fixed top-4 left-1/2 z-50 -translate-x-1/2 rounded-xl border border-primary/30 bg-primary/10 px-5 py-3 text-sm font-medium text-primary shadow-lg">

--- a/components/home/CreateRoomForm.tsx
+++ b/components/home/CreateRoomForm.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { FormEvent } from "react";
+import { FormEvent, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 
 type CreateRoomFormProps = {
-  onSubmit: () => Promise<void>;
+  onSubmit: (visibility: "public" | "private") => Promise<void>;
   loading?: boolean;
 };
 
@@ -13,9 +13,11 @@ export default function CreateRoomForm({
   onSubmit,
   loading = false,
 }: CreateRoomFormProps) {
+  const [visibility, setVisibility] = useState<"public" | "private">("private");
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    await onSubmit();
+    await onSubmit(visibility);
   }
 
   return (
@@ -26,6 +28,31 @@ export default function CreateRoomForm({
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Room visibility</label>
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                type="button"
+                variant={visibility === "private" ? "default" : "outline"}
+                onClick={() => setVisibility("private")}
+                disabled={loading}
+              >
+                Private
+              </Button>
+              <Button
+                type="button"
+                variant={visibility === "public" ? "default" : "outline"}
+                onClick={() => setVisibility("public")}
+                disabled={loading}
+              >
+                Public
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Public rooms appear in the active lobby list. Private rooms can only be joined by room code.
+            </p>
+          </div>
+
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? "Creating..." : "Create Room"}
           </Button>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,6 +1,7 @@
 import type {
   CreateRoomResponse,
   JoinRoomResponse,
+  PublicRoomSummary,
   RoomSnapshot,
   BingoCell,
 } from "./types";
@@ -22,14 +23,22 @@ async function handleResponse<T>(res: Response): Promise<T> {
 
 export async function createRoom(
   hostName: string,
-  hostId: string
+  hostId: string,
+  visibility: "public" | "private" = "private"
 ): Promise<CreateRoomResponse> {
   const res = await fetch(`${API_BASE_URL}/rooms`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ host_name: hostName, host_id: hostId }),
+    body: JSON.stringify({ host_name: hostName, host_id: hostId, visibility }),
   });
   return handleResponse<CreateRoomResponse>(res);
+}
+
+export async function getPublicRooms(): Promise<PublicRoomSummary[]> {
+  const res = await fetch(`${API_BASE_URL}/rooms/public`, {
+    cache: "no-store",
+  });
+  return handleResponse<PublicRoomSummary[]>(res);
 }
 
 export async function joinRoom(
@@ -121,5 +130,5 @@ export function getRoomWebSocketUrl(
     player_id: playerId,
     name: playerName,
   });
-  return `${base}/ws/${roomCode}?${query.toString()}`;
+  return `${base}/ws/rooms/${roomCode}?${query.toString()}`;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,7 +10,9 @@ export type PlayerSummary = {
 export type RoomSnapshot = {
   room_code: string;
   host_id: string;
+  visibility: "public" | "private";
   status: "waiting" | "in_progress" | "finished";
+  ended_by_host: boolean;
   players: PlayerSummary[];
   called_numbers: number[];
   current_number: number | null;
@@ -20,6 +22,7 @@ export type RoomSnapshot = {
 export type CreateRoomRequest = {
   host_name: string;
   host_id: string;
+  visibility: "public" | "private";
 };
 
 export type CreateRoomResponse = {
@@ -39,4 +42,12 @@ export type JoinRoomResponse = {
   player_id: string;
   room_code: string;
   card: BingoCell[][];
+};
+
+export type PublicRoomSummary = {
+  room_code: string;
+  host_id: string;
+  status: "waiting" | "in_progress";
+  total_players: number;
+  connected_players: number;
 };


### PR DESCRIPTION
Summary

Added room visibility support so hosts can create either private or public bingo rooms.
Added public lobby join flow through Quick Play, which randomly joins an active public room.
Kept direct room-code join for private rooms and manual joins.
Included backend room expiration cleanup for empty rooms after 10 seconds.
Backend changes

Added visibility on room creation: public or private.
Added public rooms API endpoint for active public rooms.
Updated in-memory room state and snapshots to include visibility.
Added automatic empty-room termination after 10 seconds with cancellation if someone reconnects.
Cleaned up unused lobby realtime/list infrastructure after UX simplification to Quick Play only.
Kept room gameplay websocket path stable under ws/rooms/{room_code}.
Frontend changes

Added visibility selection in create room flow (public/private).
Added Quick Play button that fetches active public rooms and joins one at random.
Removed lobby list UI and realtime lobby display logic (as requested).
Preserved re-enter last room behavior after leaving.
Improved room action error handling to avoid unhandled promise errors.