### PR TITLE
Add player role colors and real-time quick chat in room player list

### DIFF
--- a/app/room/[roomCode]/page.tsx
+++ b/app/room/[roomCode]/page.tsx
@@ -234,7 +234,7 @@ export default function RoomPage() {
             );
           }}
         />
-        <PlayerList players={room.players} />
+        <PlayerList players={room.players} currentPlayerId={playerId} />
       </div>
 
       <WinnerModal

--- a/app/room/[roomCode]/page.tsx
+++ b/app/room/[roomCode]/page.tsx
@@ -15,6 +15,7 @@ import {
   getRoomWebSocketUrl,
   endSession,
   leaveRoom,
+  sendQuickChat,
 } from "@/lib/api";
 
 import type { BingoCell, RoomSnapshot } from "@/lib/types";
@@ -46,6 +47,8 @@ export default function RoomPage() {
   const [error, setError] = useState("");
   const [actionLoading, setActionLoading] = useState(false);
   const [markedCells, setMarkedCells] = useState<string[]>([]);
+  const [activeQuickChats, setActiveQuickChats] = useState<Record<string, string>>({});
+  const quickChatTimeoutsRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   // Track previous host to detect failover
   const prevHostIdRef = useRef<string | null>(null);
@@ -110,6 +113,30 @@ export default function RoomPage() {
         if (data.type === "session_ended") {
           setShowSessionEndedModal(true);
         }
+
+        if (data.type === "quick_chat" && data.player_id && data.message) {
+          const chatPlayerId = String(data.player_id);
+          const chatMessage = String(data.message);
+
+          setActiveQuickChats((prev) => ({
+            ...prev,
+            [chatPlayerId]: chatMessage,
+          }));
+
+          const existingTimeout = quickChatTimeoutsRef.current[chatPlayerId];
+          if (existingTimeout) {
+            clearTimeout(existingTimeout);
+          }
+
+          quickChatTimeoutsRef.current[chatPlayerId] = setTimeout(() => {
+            setActiveQuickChats((prev) => {
+              const next = { ...prev };
+              delete next[chatPlayerId];
+              return next;
+            });
+            delete quickChatTimeoutsRef.current[chatPlayerId];
+          }, 4000);
+        }
       } catch (err) {
         console.error("WebSocket parse error:", err);
       }
@@ -117,7 +144,11 @@ export default function RoomPage() {
 
     ws.onerror = (err) => console.error("WebSocket error:", err);
 
-    return () => ws.close();
+    return () => {
+      ws.close();
+      Object.values(quickChatTimeoutsRef.current).forEach((timerId) => clearTimeout(timerId));
+      quickChatTimeoutsRef.current = {};
+    };
   }, [roomCode, playerId, playerName]);
 
   const isHost = useMemo(() => {
@@ -170,6 +201,15 @@ export default function RoomPage() {
       }
     }
     router.push("/");
+  }
+
+  async function handleSendQuickChat(message: string) {
+    if (!roomCode || !playerId) return;
+    try {
+      await sendQuickChat(roomCode, playerId, message);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send quick chat");
+    }
   }
 
   if (!room) {
@@ -234,7 +274,12 @@ export default function RoomPage() {
             );
           }}
         />
-        <PlayerList players={room.players} currentPlayerId={playerId} />
+        <PlayerList
+          players={room.players}
+          currentPlayerId={playerId}
+          activeQuickChats={activeQuickChats}
+          onSendQuickChat={handleSendQuickChat}
+        />
       </div>
 
       <WinnerModal

--- a/components/room/PlayerList.tsx
+++ b/components/room/PlayerList.tsx
@@ -3,23 +3,52 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 type PlayerListProps = {
   players: PlayerSummary[];
+  currentPlayerId?: string;
 };
 
-export default function PlayerList({ players }: PlayerListProps) {
+export default function PlayerList({ players, currentPlayerId }: PlayerListProps) {
+  function getPlayerStyle(player: PlayerSummary) {
+    if (player.player_id === currentPlayerId) {
+      return {
+        container: "border-emerald-300 bg-emerald-100/70",
+        meta: "text-emerald-900",
+      };
+    }
+
+    if (player.is_host) {
+      return {
+        container: "border-amber-300 bg-amber-100/70",
+        meta: "text-amber-900",
+      };
+    }
+
+    return {
+      container: "border-rose-300 bg-rose-100/70",
+      meta: "text-rose-900",
+    };
+  }
+
   return (
     <Card className="rounded-2xl">
       <CardHeader>
         <CardTitle>Players</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
-        {players.map((player) => (
-          <div key={player.player_id} className="rounded-xl border bg-muted/50 px-4 py-3">
+        {players.map((player) => {
+          const style = getPlayerStyle(player);
+
+          return (
+          <div
+            key={player.player_id}
+            className={`rounded-xl border px-4 py-3 ${style.container}`}
+          >
             <div className="font-medium">{player.player_name}</div>
-            <div className="text-sm text-muted-foreground">
+            <div className={`text-sm ${style.meta}`}>
               {player.is_host ? "Host" : "Player"} · {player.connected ? "Connected" : "Disconnected"}
             </div>
           </div>
-        ))}
+          );
+        })}
       </CardContent>
     </Card>
   );

--- a/components/room/PlayerList.tsx
+++ b/components/room/PlayerList.tsx
@@ -1,12 +1,40 @@
+"use client";
+
+import { useState } from "react";
 import type { PlayerSummary } from "@/lib/types";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 type PlayerListProps = {
   players: PlayerSummary[];
   currentPlayerId?: string;
+  activeQuickChats?: Record<string, string>;
+  onSendQuickChat?: (message: string) => Promise<void> | void;
 };
 
-export default function PlayerList({ players, currentPlayerId }: PlayerListProps) {
+const QUICK_CHAT_OPTIONS = [
+  "Good luck!",
+  "I am close to bingo!",
+  "This is getting intense!",
+  "GG!",
+];
+
+export default function PlayerList({
+  players,
+  currentPlayerId,
+  activeQuickChats = {},
+  onSendQuickChat,
+}: PlayerListProps) {
+  const [showQuickChatMenu, setShowQuickChatMenu] = useState(false);
+  const [customQuickChat, setCustomQuickChat] = useState("");
+
+  function sendQuickChat(message: string) {
+    const normalized = message.trim();
+    if (!normalized) return;
+    onSendQuickChat?.(normalized.slice(0, 80));
+    setShowQuickChatMenu(false);
+    setCustomQuickChat("");
+  }
+
   function getPlayerStyle(player: PlayerSummary) {
     if (player.player_id === currentPlayerId) {
       return {
@@ -36,17 +64,79 @@ export default function PlayerList({ players, currentPlayerId }: PlayerListProps
       <CardContent className="space-y-3">
         {players.map((player) => {
           const style = getPlayerStyle(player);
+          const isCurrentPlayer = player.player_id === currentPlayerId;
+          const quickChat = activeQuickChats[player.player_id];
 
           return (
-          <div
-            key={player.player_id}
-            className={`rounded-xl border px-4 py-3 ${style.container}`}
-          >
-            <div className="font-medium">{player.player_name}</div>
-            <div className={`text-sm ${style.meta}`}>
-              {player.is_host ? "Host" : "Player"} · {player.connected ? "Connected" : "Disconnected"}
+            <div
+              key={player.player_id}
+              className={`rounded-xl border px-4 py-3 ${style.container}`}
+            >
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium">{player.player_name}</div>
+                  <div className={`text-sm ${style.meta}`}>
+                    {player.is_host ? "Host" : "Player"} · {player.connected ? "Connected" : "Disconnected"}
+                  </div>
+                  {quickChat ? (
+                    <div className="mt-1 inline-block rounded-md border border-current/20 bg-white/65 px-2 py-1 text-xs font-medium">
+                      {quickChat}
+                    </div>
+                  ) : null}
+                </div>
+
+                {isCurrentPlayer ? (
+                  <div className="relative shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => setShowQuickChatMenu((prev) => !prev)}
+                      className="flex h-12 w-12 items-center justify-center rounded-full border border-current/25 bg-white/65 text-base font-semibold leading-none hover:bg-white/85"
+                      aria-label="Open quick chat"
+                    >
+                      ...
+                    </button>
+                    {showQuickChatMenu ? (
+                      <div className="absolute right-0 top-14 z-20 min-w-52 rounded-lg border bg-background p-2 shadow-lg">
+                        <div className="mb-2 flex items-center gap-2">
+                          <input
+                            type="text"
+                            value={customQuickChat}
+                            onChange={(event) => setCustomQuickChat(event.target.value)}
+                            onKeyDown={(event) => {
+                              if (event.key === "Enter") {
+                                sendQuickChat(customQuickChat);
+                              }
+                            }}
+                            placeholder="Type quick chat"
+                            maxLength={80}
+                            className="h-8 w-full rounded-md border bg-background px-2 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => sendQuickChat(customQuickChat)}
+                            className="h-8 rounded-md border px-2 text-xs font-medium hover:bg-muted"
+                          >
+                            Send
+                          </button>
+                        </div>
+                        {QUICK_CHAT_OPTIONS.map((message) => (
+                          <button
+                            key={message}
+                            type="button"
+                            className="block w-full rounded-md px-2 py-1.5 text-left text-xs hover:bg-muted"
+                            onClick={() => {
+                              sendQuickChat(message);
+                            }}
+                          >
+                            {message}
+                          </button>
+                        ))}
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
             </div>
-          </div>
           );
         })}
       </CardContent>

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -97,6 +97,15 @@ export async function endSession(roomCode: string, hostId: string) {
   return handleResponse<{ room: RoomSnapshot }>(res);
 }
 
+export async function sendQuickChat(roomCode: string, playerId: string, message: string) {
+  const res = await fetch(`${API_BASE_URL}/rooms/${roomCode}/quick-chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ player_id: playerId, message }),
+  });
+  return handleResponse<{ ok: boolean }>(res);
+}
+
 export async function leaveRoom(roomCode: string, playerId: string) {
   const res = await fetch(`${API_BASE_URL}/players/leave`, {
     method: "POST",


### PR DESCRIPTION
This PR adds two room UX features:

Color-coded players
Host is shown in yellow
Current user (You) is shown in green
Other players are shown in red
Colors update in real time from room updates
Quick chat
Added a quick-chat trigger button (...) shown only on the current user row
Added preset quick-chat options and a custom input with Send/Enter support
Quick chat is broadcast in real time and displayed on the sender row for all players
Messages are temporary and auto-clear after a few seconds
No chat history is stored
Backend updates:

Added quick chat API endpoint for room broadcast
Added message validation for sender and content
Improved websocket presence handling with disconnect grace period so host reload does not immediately trigger host reassignment
Frontend updates:

Updated player list row layout and styling
Added quick chat popup UI and temporary message rendering
Added API client support for sending quick chat
Added websocket handling for quick chat events