### PR TITLE
Add collapsible, responsive called-numbers (inline-right) and hydration tolerance

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
       lang="en"
       className={`${fraunces.variable} ${dmSans.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body suppressHydrationWarning className="min-h-full flex flex-col" data-gr-ext-installed="">{children}</body>
     </html>
   );
 }

--- a/components/room/CalledNumbers.tsx
+++ b/components/room/CalledNumbers.tsx
@@ -1,5 +1,14 @@
+"use client";
+
 import Image from "next/image";
+import { useState } from "react";
 import type { ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import ballB from "@/components/assets/B_ball.svg";
 import ballI from "@/components/assets/I_ball.svg";
@@ -29,61 +38,76 @@ const BALL_ASSETS: Record<string, typeof ballB> = {
 };
 
 export default function CalledNumbers({ numbers, action }: CalledNumbersProps) {
+  const [collapsed, setCollapsed] = useState(true);
+
   const recentNumbers = [...numbers].reverse();
   const [currentNumber, ...previousNumbers] = recentNumbers;
 
   return (
     <Card className="bg-transparent shadow-none">
-      <CardHeader className="flex flex-row items-center justify-between gap-2 px-3 pb-2 sm:px-6">
+      <Collapsible open={!collapsed} onOpenChange={(open) => setCollapsed(!open)}>
+        <CardHeader className="flex flex-row items-center justify-between gap-2 px-3 pb-2 sm:px-6">
         <CardTitle className="text-base font-semibold text-slate-900 sm:text-lg">
           Called Numbers
         </CardTitle>
-        {action ? <div className="shrink-0">{action}</div> : null}
+        <div className="flex items-center gap-2">
+          {action ? <div className="shrink-0">{action}</div> : null}
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" size="sm" className="shrink-0">
+              {collapsed ? `Show previous (${previousNumbers.length})` : "Hide previous"}
+            </Button>
+          </CollapsibleTrigger>
+        </div>
       </CardHeader>
       <CardContent className="px-3 pb-3 sm:px-6 sm:pb-6">
-        {recentNumbers.length ? (
-          <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-            {currentNumber !== undefined ? (() => {
-              const letter = getBingoLetter(currentNumber);
-              const asset = BALL_ASSETS[letter];
-              return (
-                <div className="flex items-center gap-2 rounded-2xl px-1 py-1">
-                  <div className="relative h-12 w-12 sm:h-16 sm:w-16">
-                    <Image src={asset} alt={`${letter} ball`} fill className="object-contain" />
-                    <div className="absolute inset-0 flex items-center justify-center font-bold text-slate-900 top-2">
-                      <span className="text-sm sm:text-lg">{currentNumber}</span>
-                    </div>
-                  </div>
-    
-                </div>
-              );
-            })() : null}
-
-            {previousNumbers.length ? (
-              <div className="flex flex-1 flex-wrap items-center gap-0.5">
-                {previousNumbers.map((num, index) => {
-                  const letter = getBingoLetter(num);
-                  return (
-                    <div key={`${num}-${index}`} className="relative h-8 w-8 sm:h-10 sm:w-10">
-                      <Image
-                        src={BALL_ASSETS[letter]}
-                        alt={`${letter} ball`}
-                        fill
-                        className="object-contain"
-                      />
-                      <div className="absolute inset-0 flex items-center justify-center font-bold text-slate-90 top-1">
-                        <span className="text-[10px] sm:text-xs">{num}</span>
+          {recentNumbers.length ? (
+            <div className="flex w-full items-center gap-4 relative min-w-0">
+              {currentNumber !== undefined ? (() => {
+                const letter = getBingoLetter(currentNumber);
+                const asset = BALL_ASSETS[letter];
+                return (
+                  <div className="flex items-center gap-2 rounded-2xl px-1 py-1">
+                    <div className="relative h-12 w-12 sm:h-16 sm:w-16">
+                      <Image src={asset} alt={`${letter} ball`} fill className="object-contain" />
+                      <div className="absolute inset-0 flex items-center justify-center font-bold text-slate-900 top-2">
+                        <span className="text-sm sm:text-lg">{currentNumber}</span>
                       </div>
                     </div>
-                  );
-                })}
+
+                  </div>
+                );
+              })() : null}
+              <div className="flex-1 min-w-0">
+                <CollapsibleContent>
+                  {previousNumbers.length ? (
+                    <div className="flex items-center gap-2 overflow-x-auto max-w-full">
+                      {previousNumbers.map((num, index) => {
+                        const letter = getBingoLetter(num);
+                        return (
+                          <div key={`${num}-${index}`} className="relative inline-block h-8 w-8 sm:h-10 sm:w-10 mr-2 flex-shrink-0">
+                            <Image
+                              src={BALL_ASSETS[letter]}
+                              alt={`${letter} ball`}
+                              fill
+                              className="object-contain"
+                            />
+                            <div className="absolute inset-0 flex items-center justify-center font-bold text-slate-90 top-1">
+                              <span className="text-[10px] sm:text-xs">{num}</span>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ) : null}
+                </CollapsibleContent>
               </div>
-            ) : null}
-          </div>
-        ) : (
-          <span className="text-sm text-muted-foreground">No numbers called yet.</span>
-        )}
-      </CardContent>
+            </div>
+          ) : (
+            <span className="text-sm text-muted-foreground">No numbers called yet.</span>
+          )}
+          
+        </CardContent>
+      </Collapsible>
     </Card>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -74,7 +74,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -599,7 +598,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1770,7 +1768,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3787,7 +3784,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3798,7 +3794,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3809,7 +3804,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3880,7 +3874,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -4419,7 +4412,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4867,7 +4859,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5831,7 +5822,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6017,7 +6007,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6307,7 +6296,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7030,7 +7018,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
       "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9432,7 +9419,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9442,7 +9428,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10530,8 +10515,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -10603,7 +10587,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10852,7 +10835,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11431,7 +11413,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
Summary

Adds a collapsible "Show previous" / "Hide previous" control to the Called Numbers card and renders previous numbers inline to the right of the current ball. On small screens the previous numbers horizontally scroll instead of overflowing.
Fixes several issues: duplicate rendering, a JSX parse error, and a runtime error where [CollapsibleTrigger](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was used outside [Collapsible](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Adds a light hydration-tolerance change to the root layout to reduce console noise from browser extensions injecting attributes.
What changed

components/room/CalledNumbers.tsx
Converted to client component.
Uses [Collapsible](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [CollapsibleTrigger](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [CollapsibleContent](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Current number shown large on the left; previous numbers appear inline to the right and scroll on small viewports.
Removed duplicate previous-numbers block and fixed JSX/trigger placement bugs.
app/layout.tsx
Added [suppressHydrationWarning](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [data-gr-ext-installed=""](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on [<body>](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to reduce hydration mismatch warnings caused by client-side extension injections.Summary

Adds a collapsible "Show previous" / "Hide previous" control to the Called Numbers card and renders previous numbers inline to the right of the current ball. On small screens the previous numbers horizontally scroll instead of overflowing.
Fixes several issues: duplicate rendering, a JSX parse error, and a runtime error where [CollapsibleTrigger](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was used outside [Collapsible](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Adds a light hydration-tolerance change to the root layout to reduce console noise from browser extensions injecting attributes.
What changed

components/room/CalledNumbers.tsx
Converted to client component.
Uses [Collapsible](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [CollapsibleTrigger](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html), [CollapsibleContent](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Current number shown large on the left; previous numbers appear inline to the right and scroll on small viewports.
Removed duplicate previous-numbers block and fixed JSX/trigger placement bugs.
app/layout.tsx
Added [suppressHydrationWarning](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [data-gr-ext-installed=""](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) on [<body>](vscode-file://vscode-app/c:/Users/JESREAL/AppData/Local/Programs/Microsoft%20VS%20Code/034f571df5/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to reduce hydration mismatch warnings caused by client-side extension injections.



<img width="860" height="175" alt="image" src="https://github.com/user-attachments/assets/4927f58a-9699-4cd7-80bf-94ad7622d98a" />
<img width="860" height="175" alt="image" src="https://github.com/user-attachments/assets/4927f58a-9699-4cd7-80bf-94ad7622d98a" />
<img width="857" height="179" alt="image" src="https://github.com/user-attachments/assets/cf2780c1-f62f-43a0-a52f-4dbc7abe802e" />
<img width="857" height="179" alt="image" src="https://github.com/user-attachments/assets/cf2780c1-f62f-43a0-a52f-4dbc7abe802e" />
