### PR TITLE
 UI: wrap long quick-chat messages to prevent overlap

### DIFF
--- a/components/room/PlayerList.tsx
+++ b/components/room/PlayerList.tsx
@@ -64,9 +64,9 @@ export default function PlayerList({
                     {player.is_host ? "Host" : "Player"} · {player.connected ? "Connected" : "Disconnected"}
                   </div>
                   {quickChat ? (
-                    <div className="inline-flex items-center gap-2 rounded-full border border-white/70 bg-white/80 px-3 py-1 text-xs font-semibold text-slate-700 shadow-sm">
+                    <div className="inline-flex items-center gap-2 rounded-xl border border-white/70 bg-white/80 px-3 py-2 text-xs font-semibold text-slate-700 shadow-sm max-w-[70%]">
                       <span className="text-slate-500">💬</span>
-                      <span className="truncate">{quickChat}</span>
+                      <span className="whitespace-normal break-words break-all">{quickChat}</span>
                     </div>
                   ) : null}
                 </div>


### PR DESCRIPTION
Summary: Fixes a UI bug where very long quick-chat messages overflowed and overlapped other elements in the player list.
What I changed: Updated components/room/PlayerList.tsx to constrain the quick-chat bubble and enable wrapping/breaking of long or unbroken strings (replaced truncate with whitespace-normal break-words break-all, set a max-w on the bubble and adjusted padding/shape).